### PR TITLE
Changed Temp Texture Filter Mode to Bilinear in Unity 2022.1 and up

### DIFF
--- a/UnifiedUniversalBlur/Scripts/UniversalBlurPass.cs
+++ b/UnifiedUniversalBlur/Scripts/UniversalBlurPass.cs
@@ -28,8 +28,8 @@ namespace Unified.Universal.Blur
             m_PassData.rtDesc.height = Mathf.RoundToInt(m_PassData.rtDesc.height / downsample);
 
 		#if UNITY_2022_1_OR_NEWER
-		    RenderingUtils.ReAllocateIfNeeded(ref m_PassData.tmpRT1, m_PassData.rtDesc, name: "_PassRT1", wrapMode: TextureWrapMode.Clamp);
-		    RenderingUtils.ReAllocateIfNeeded(ref m_PassData.tmpRT2, m_PassData.rtDesc, name: "_PassRT2", wrapMode: TextureWrapMode.Clamp);
+		    RenderingUtils.ReAllocateIfNeeded(ref m_PassData.tmpRT1, m_PassData.rtDesc, name: "_PassRT1", wrapMode: TextureWrapMode.Clamp, filterMode: FilterMode.Bilinear);
+		    RenderingUtils.ReAllocateIfNeeded(ref m_PassData.tmpRT2, m_PassData.rtDesc, name: "_PassRT2", wrapMode: TextureWrapMode.Clamp, filterMode: FilterMode.Bilinear);
         #else
             m_PassData.tmpRT1 ??= new RenderTexture(m_PassData.rtDesc);
             m_PassData.tmpRT2 ??= new RenderTexture(m_PassData.rtDesc);


### PR DESCRIPTION
I changed the Filter Mode of the temp textures, as `RenderingUtils.ReAllocateIfNeeded(...)` sometimes defaults to Point Filtering when allocating a texture.
Kawase Blur relies on Bilinear Filtering as it makes use of the hardware interpolation unit of the GPU to do the bluring.