### PR TITLE
Make Editor assembly only compile for Editor

### DIFF
--- a/Editor/Unified.UniversalBlur.Editor.asmdef
+++ b/Editor/Unified.UniversalBlur.Editor.asmdef
@@ -6,7 +6,9 @@
         "GUID:3eae0364be2026648bf74846acb8a731",
         "GUID:15fc0a57446b3144c949da3e2b9737a9"
     ],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,


### PR DESCRIPTION
![image](https://github.com/lukakldiashvili/Unified-Universal-Blur-Sandbox/assets/4276275/60533a3b-17ff-426c-991e-31d173147976)

Otherwise we get an error when compiling scripts.