### PR TITLE
Fix "Skipping render pass" errors caused by missing intermediate texture

### DIFF
--- a/Runtime/UniversalBlurPass.cs
+++ b/Runtime/UniversalBlurPass.cs
@@ -34,6 +34,9 @@ namespace Unified.UniversalBlur.Runtime
         public void Setup(BlurConfig blurConfig)
         {
             _blurConfig = blurConfig;
+
+            // declare the need for intermediate texture
+            ConfigureInput(ScriptableRenderPassInput.Color);
         }
 
         public void Dispose()

--- a/Runtime/UniversalBlurPass.cs
+++ b/Runtime/UniversalBlurPass.cs
@@ -24,7 +24,7 @@ namespace Unified.UniversalBlur.Runtime
         private BlurConfig _blurConfig;
         private RTHandle _sourceRT;
         private RTHandle _destinationRT;
-
+        
         public UniversalBlurPass()
         {
             _profilingSampler = new(k_PassName);
@@ -43,7 +43,7 @@ namespace Unified.UniversalBlur.Runtime
         {
             // Nothing to dispose
         }
-
+        
         public void DrawDefaultTexture()
         {
             // For better preview experience in editor, we just use a gray texture
@@ -57,7 +57,6 @@ namespace Unified.UniversalBlur.Runtime
                 autoGenerateMips = _blurConfig.EnableMipMaps
             };
 
-        [Obsolete("This rendering path is for compatibility mode only (when Render Graph is disabled). Use Render Graph API instead.", false)]
         public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
         {
             var cmd = CommandBufferPool.Get();
@@ -67,11 +66,11 @@ namespace Unified.UniversalBlur.Runtime
 #if UNITY_6000_0_OR_NEWER
             RenderingUtils.ReAllocateHandleIfNeeded(ref _sourceRT, descriptor, FilterMode.Bilinear, TextureWrapMode.Clamp, name: k_BlurTextureSourceName);
             RenderingUtils.ReAllocateHandleIfNeeded(ref _destinationRT, descriptor, FilterMode.Bilinear, TextureWrapMode.Clamp, name: k_BlurTextureDestinationName);
-#else
+            #else
             RenderingUtils.ReAllocateIfNeeded(ref _sourceRT, descriptor, FilterMode.Bilinear, TextureWrapMode.Clamp, name: k_BlurTextureSourceName);
             RenderingUtils.ReAllocateIfNeeded(ref _destinationRT, descriptor, FilterMode.Bilinear, TextureWrapMode.Clamp, name: k_BlurTextureDestinationName);
-#endif
-
+            #endif
+            
 
             var colorTarget = renderingData.cameraData.renderer.cameraColorTargetHandle;
 
@@ -106,14 +105,14 @@ namespace Unified.UniversalBlur.Runtime
             }
 
             var cameraColorSource = resourceData.activeColorTexture;
-
+            
             var descriptor = new TextureDesc(GetDescriptor());
 
             descriptor.name = k_BlurTextureSourceName;
             TextureHandle source = renderGraph.CreateTexture(descriptor);
             descriptor.name = k_BlurTextureDestinationName;
             TextureHandle destination = renderGraph.CreateTexture(descriptor);
-
+            
             using (var builder = renderGraph.AddUnsafePass<RenderGraphPassData>(k_PassName, out var passData, _profilingSampler))
             {
                 passData.ColorSource = cameraColorSource;
@@ -121,16 +120,16 @@ namespace Unified.UniversalBlur.Runtime
                 passData.Destination = destination;
 
                 passData.MaterialPropertyBlock = _propertyBlock;
-
+                
                 passData.BlurConfig = _blurConfig;
-
+                
                 builder.AllowPassCulling(false);
-
+                
                 builder.UseTexture(source, AccessFlags.ReadWrite);
                 builder.UseTexture(destination, AccessFlags.ReadWrite);
-
+                
                 builder.SetGlobalTextureAfterPass(destination, Constants.GlobalFullScreenBlurTextureId);
-
+                
                 builder.SetRenderFunc<RenderGraphPassData>((data, ctx) =>
                 {
                     BlurPasses.KawaseExecutePass(data, new WrappedUnsafeCommandBuffer(ctx.cmd));

--- a/Runtime/UniversalBlurPass.cs
+++ b/Runtime/UniversalBlurPass.cs
@@ -24,7 +24,7 @@ namespace Unified.UniversalBlur.Runtime
         private BlurConfig _blurConfig;
         private RTHandle _sourceRT;
         private RTHandle _destinationRT;
-        
+
         public UniversalBlurPass()
         {
             _profilingSampler = new(k_PassName);
@@ -43,7 +43,7 @@ namespace Unified.UniversalBlur.Runtime
         {
             // Nothing to dispose
         }
-        
+
         public void DrawDefaultTexture()
         {
             // For better preview experience in editor, we just use a gray texture
@@ -57,6 +57,7 @@ namespace Unified.UniversalBlur.Runtime
                 autoGenerateMips = _blurConfig.EnableMipMaps
             };
 
+        [Obsolete("This rendering path is for compatibility mode only (when Render Graph is disabled). Use Render Graph API instead.", false)]
         public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
         {
             var cmd = CommandBufferPool.Get();
@@ -66,11 +67,11 @@ namespace Unified.UniversalBlur.Runtime
 #if UNITY_6000_0_OR_NEWER
             RenderingUtils.ReAllocateHandleIfNeeded(ref _sourceRT, descriptor, FilterMode.Bilinear, TextureWrapMode.Clamp, name: k_BlurTextureSourceName);
             RenderingUtils.ReAllocateHandleIfNeeded(ref _destinationRT, descriptor, FilterMode.Bilinear, TextureWrapMode.Clamp, name: k_BlurTextureDestinationName);
-            #else
+#else
             RenderingUtils.ReAllocateIfNeeded(ref _sourceRT, descriptor, FilterMode.Bilinear, TextureWrapMode.Clamp, name: k_BlurTextureSourceName);
             RenderingUtils.ReAllocateIfNeeded(ref _destinationRT, descriptor, FilterMode.Bilinear, TextureWrapMode.Clamp, name: k_BlurTextureDestinationName);
-            #endif
-            
+#endif
+
 
             var colorTarget = renderingData.cameraData.renderer.cameraColorTargetHandle;
 
@@ -105,14 +106,14 @@ namespace Unified.UniversalBlur.Runtime
             }
 
             var cameraColorSource = resourceData.activeColorTexture;
-            
+
             var descriptor = new TextureDesc(GetDescriptor());
 
             descriptor.name = k_BlurTextureSourceName;
             TextureHandle source = renderGraph.CreateTexture(descriptor);
             descriptor.name = k_BlurTextureDestinationName;
             TextureHandle destination = renderGraph.CreateTexture(descriptor);
-            
+
             using (var builder = renderGraph.AddUnsafePass<RenderGraphPassData>(k_PassName, out var passData, _profilingSampler))
             {
                 passData.ColorSource = cameraColorSource;
@@ -120,16 +121,16 @@ namespace Unified.UniversalBlur.Runtime
                 passData.Destination = destination;
 
                 passData.MaterialPropertyBlock = _propertyBlock;
-                
+
                 passData.BlurConfig = _blurConfig;
-                
+
                 builder.AllowPassCulling(false);
-                
+
                 builder.UseTexture(source, AccessFlags.ReadWrite);
                 builder.UseTexture(destination, AccessFlags.ReadWrite);
-                
+
                 builder.SetGlobalTextureAfterPass(destination, Constants.GlobalFullScreenBlurTextureId);
-                
+
                 builder.SetRenderFunc<RenderGraphPassData>((data, ctx) =>
                 {
                     BlurPasses.KawaseExecutePass(data, new WrappedUnsafeCommandBuffer(ctx.cmd));


### PR DESCRIPTION
From what I understand, URP only creates an intermediate texture when one of its render passes declares a need for it. On my project, we have not post-processing enabled so, by default, the intermediate texture is not created. This causes the UniversalBlurPass not to work and log this error:
``Skipping render pass. UniversalBlurPass requires an intermediate ColorTexture, we can't use the BackBuffer as a texture input.``

To fix this, I declared the need for the color texture in the setup method, based on this [doc](https://docs.unity3d.com/6000.0/Documentation/Manual/urp/renderer-features/how-to-fullscreen-blit.html).