### PR TITLE
Fix/unity 6 3 rendering issues

### DIFF
--- a/Runtime/UniversalBlurPass.cs
+++ b/Runtime/UniversalBlurPass.cs
@@ -93,51 +93,54 @@ namespace Unified.UniversalBlur.Runtime
             context.ExecuteCommandBuffer(cmd);
             CommandBufferPool.Release(cmd);
         }
-
+  
 #if UNITY_6000_0_OR_NEWER
-    public override void RecordRenderGraph(RenderGraph renderGraph, ContextContainer frameData)
+public override void RecordRenderGraph(RenderGraph renderGraph, ContextContainer frameData)
+{
+    var resourceData = frameData.Get<UniversalResourceData>();
+    
+    TextureHandle cameraColorSource;
+    if (resourceData.isActiveTargetBackBuffer)
+    {
+        cameraColorSource = resourceData.afterPostProcessColor.IsValid()
+            ? resourceData.afterPostProcessColor
+            : resourceData.cameraColor;
+    }
+    else
+    {
+        cameraColorSource = resourceData.activeColorTexture;
+    }
+
+    var desc = new TextureDesc(GetDescriptor())
+    {
+        name = k_BlurTextureSourceName
+    };
+    var source = renderGraph.CreateTexture(desc);
+
+    desc.name = k_BlurTextureDestinationName;
+    var destination = renderGraph.CreateTexture(desc);
+
+    using (var builder = renderGraph.AddUnsafePass<RenderGraphPassData>(k_PassName, out var passData, _profilingSampler))
+    {
+        passData.ColorSource = cameraColorSource;
+        passData.Source = source;
+        passData.Destination = destination;
+        passData.MaterialPropertyBlock = _propertyBlock;
+        passData.BlurConfig = _blurConfig;
+
+        builder.AllowPassCulling(false);
+        builder.UseTexture(passData.ColorSource, AccessFlags.Read);
+        builder.UseTexture(passData.Source, AccessFlags.ReadWrite);
+        builder.UseTexture(passData.Destination, AccessFlags.ReadWrite);
+
+        builder.SetGlobalTextureAfterPass(passData.Destination, Constants.GlobalFullScreenBlurTextureId);
+
+        builder.SetRenderFunc<RenderGraphPassData>((data, ctx) =>
         {
-            var resourceData = frameData.Get<UniversalResourceData>();
-
-            if (resourceData.isActiveTargetBackBuffer)
-            {
-                Debug.LogError(
-                    $"Skipping render pass. UniversalBlurPass requires an intermediate ColorTexture, we can't use the BackBuffer as a texture input.");
-                return;
-            }
-
-            var cameraColorSource = resourceData.activeColorTexture;
-            
-            var descriptor = new TextureDesc(GetDescriptor());
-
-            descriptor.name = k_BlurTextureSourceName;
-            TextureHandle source = renderGraph.CreateTexture(descriptor);
-            descriptor.name = k_BlurTextureDestinationName;
-            TextureHandle destination = renderGraph.CreateTexture(descriptor);
-            
-            using (var builder = renderGraph.AddUnsafePass<RenderGraphPassData>(k_PassName, out var passData, _profilingSampler))
-            {
-                passData.ColorSource = cameraColorSource;
-                passData.Source = source;
-                passData.Destination = destination;
-
-                passData.MaterialPropertyBlock = _propertyBlock;
-                
-                passData.BlurConfig = _blurConfig;
-                
-                builder.AllowPassCulling(false);
-                
-                builder.UseTexture(source, AccessFlags.ReadWrite);
-                builder.UseTexture(destination, AccessFlags.ReadWrite);
-                
-                builder.SetGlobalTextureAfterPass(destination, Constants.GlobalFullScreenBlurTextureId);
-                
-                builder.SetRenderFunc<RenderGraphPassData>((data, ctx) =>
-                {
-                    BlurPasses.KawaseExecutePass(data, new WrappedUnsafeCommandBuffer(ctx.cmd));
-                });
-            }
-        }
+            BlurPasses.KawaseExecutePass(data, new WrappedUnsafeCommandBuffer(ctx.cmd));
+        });
+    }
+}
 #endif
     }
 }

--- a/Runtime/UniversalBlurPass.cs
+++ b/Runtime/UniversalBlurPass.cs
@@ -29,6 +29,8 @@ namespace Unified.UniversalBlur.Runtime
         {
             _profilingSampler = new(k_PassName);
             _propertyBlock = new();
+            
+            requiresIntermediateTexture = true;
         }
 
         public void Setup(BlurConfig blurConfig)
@@ -93,7 +95,7 @@ namespace Unified.UniversalBlur.Runtime
         }
 
 #if UNITY_6000_0_OR_NEWER
-        public override void RecordRenderGraph(RenderGraph renderGraph, ContextContainer frameData)
+    public override void RecordRenderGraph(RenderGraph renderGraph, ContextContainer frameData)
         {
             var resourceData = frameData.Get<UniversalResourceData>();
 


### PR DESCRIPTION
I updated to unity 6.3 lts and had error

Skipping render pass. UniversalBlurPass requires an intermediate ColorTexture, we can't use the BackBuffer as a texture input. UnityEngine.Debug:LogError (object) Unified.UniversalBlur.Runtime.UniversalBlurPass:RecordRenderGraph (UnityEngine.Rendering.RenderGraphModule.RenderGraph,UnityEngine.Rendering.ContextContainer) (at ./Library/PackageCache/com.unify.unified-universal-blur@e8568b1ad09a/Runtime/UniversalBlurPass.cs:104) UnityEngine.GUIUtility:ProcessEvent (int,intptr,bool&) (at /Users/bokken/build/output/unity/unity/Modules/IMGUI/GUIUtility.cs:224)

This is how I fixed it. @lukakldiashvili Let me know if this is a valid fix or not ✌️ 