### PR TITLE
Exclude legacy Execute path on Unity 6000.4+

### DIFF
--- a/Runtime/UniversalBlurPass.cs
+++ b/Runtime/UniversalBlurPass.cs
@@ -57,6 +57,7 @@ namespace Unified.UniversalBlur.Runtime
                 autoGenerateMips = _blurConfig.EnableMipMaps
             };
 
+#if !UNITY_6000_4_OR_NEWER
         public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
         {
             var cmd = CommandBufferPool.Get();
@@ -91,7 +92,8 @@ namespace Unified.UniversalBlur.Runtime
             context.ExecuteCommandBuffer(cmd);
             CommandBufferPool.Release(cmd);
         }
-
+#endif
+        
 #if UNITY_6000_0_OR_NEWER
         public override void RecordRenderGraph(RenderGraph renderGraph, ContextContainer frameData)
         {


### PR DESCRIPTION
Execute method no longer available in Unity versions beyond 6000.4.

Resolves #54